### PR TITLE
implement (apikey) authorization  and better errors

### DIFF
--- a/fixtures/specifications/nwd.yaml
+++ b/fixtures/specifications/nwd.yaml
@@ -4,58 +4,143 @@ info:
   title: Nationaal Watersport Diploma API
   description: |-
     Nationaal Watersport Diploma API
-  version: 0.1.0
+  version: 0.2.0
 
 paths:
-  /echo:
+  /main-category:
     get:
-      operationId: echo-via-get
-      summary: Send a message via GET and get your message back in a message-container
-      description: |-
-        Send a message and get the same message back!
-      parameters:
-        - name: message
-          in: query
-          required: true
-          schema:
-            type: string
+      operationId: get-main-categories
+      summary: Get main get-main-categories
       responses:
         "200":
-          description: |-
-            A response
+          description: Ok
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/message-container"
+                type: array
+                items:
+                  $ref: "#/components/schemas/main-category"
     post:
-      operationId: echo
-      summary: Send a message
-      description: |-
-        Send a message and get the same message back!
+      operationId: create-main-category
+      summary: Create an new main category
       requestBody:
-        required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/message-container"
+              $ref: "#/components/schemas/main-category-fields"
       responses:
-        "200":
-          description: |-
-            A response
+        "201":
+          description: Created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/message-container"
+                type: array
+                items:
+                  $ref: "#/components/schemas/main-category"
+
+  /sub-category/{main-category-id}:
+    parameters:
+      - name: main-category-id
+        in: path
+        required: true
+        schema:
+          $ref: "#/components/schemas/entity-id"
+    get:
+      operationId: get-sub-categories
+      summary: Get sub categories in a main category
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/main-category"
+    post:
+      operationId: create-sub-category
+      summary: Create an new sub category in a main category
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/sub-category-fields"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/sub-category"
 
 components:
   schemas:
-    message-container:
+    #entity schemas
+
+    main-category:
       description: |-
-        Object that contains a message
+        Full main category entity
+      $ref: "#/components/schemas/main-category-fields"
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/entity-id"
+
+    main-category-fields:
+      description: |-
+        Main category editable fields
       type: object
       required:
-        - message
+        - name
       properties:
-        message:
-          type: string
-          minLength: 1
+        name:
+          $ref: "#/components/schemas/entity-name"
+        description:
+          $ref: "#/components/schemas/entity-description"
+
+    sub-category:
+      description: |-
+        Full sub category entity
+      $ref: "#/components/schemas/sub-category-fields"
+      required:
+        - id
+      properties:
+        id:
+          $ref: "#/components/schemas/entity-id"
+
+    sub-category-fields:
+      description: |-
+        Sub category entity editable fields
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          $ref: "#/components/schemas/entity-name"
+        description:
+          $ref: "#/components/schemas/entity-description"
+
+    # field schemas
+
+    entity-id:
+      description: |-
+        Key of an entity
+      type: integer
+      # exclusiveMinimum: 0
+
+    entity-name:
+      description: |-
+        The name of an entity
+      type: string
+      minLength: 1
+      maxLength: 100
+
+    entity-description:
+      description: |-
+        Description of an entity
+      type: string
+      minLength: 1
+      maxLength: 100

--- a/fixtures/specifications/nwd.yaml
+++ b/fixtures/specifications/nwd.yaml
@@ -4,7 +4,7 @@ info:
   title: Nationaal Watersport Diploma API
   description: |-
     Nationaal Watersport Diploma API
-  version: 0.2.0
+  version: 0.1.0
 
 paths:
   /main-category:
@@ -34,9 +34,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/main-category"
+                $ref: "#/components/schemas/main-category"
 
   /sub-category/{main-category-id}:
     parameters:
@@ -71,9 +69,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/sub-category"
+                $ref: "#/components/schemas/sub-category"
 
 components:
   schemas:

--- a/fixtures/specifications/nwd.yaml
+++ b/fixtures/specifications/nwd.yaml
@@ -140,3 +140,9 @@ components:
       type: string
       minLength: 1
       maxLength: 100
+
+  securitySchemes:
+    api-key:
+      type: apiKey
+      name: api-key
+      in: header

--- a/fixtures/specifications/nwd.yaml
+++ b/fixtures/specifications/nwd.yaml
@@ -6,6 +6,9 @@ info:
     Nationaal Watersport Diploma API
   version: 0.1.0
 
+security:
+  - api-token: []
+
 paths:
   /main-category:
     get:
@@ -35,6 +38,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/main-category"
+        "403":
+          $ref: "#/components/responses/forbidden"
 
   /sub-category/{main-category-id}:
     parameters:
@@ -70,6 +75,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/sub-category"
+        "403":
+          $ref: "#/components/responses/forbidden"
 
 components:
   schemas:
@@ -141,8 +148,12 @@ components:
       minLength: 1
       maxLength: 100
 
+  responses:
+    forbidden:
+      description: Forbidden
+
   securitySchemes:
-    api-key:
+    api-token:
       type: apiKey
-      name: api-key
+      name: api-token
       in: header

--- a/package-lock.json
+++ b/package-lock.json
@@ -510,9 +510,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.6.tgz",
-      "integrity": "sha512-+EOokTnksGVgip2PbYbr3xnR7kZigh4LbybAfBAw5BpnQ+FqBYUsvCEjYd70IXKlbohQ64mzEYmMtlWUY8q//Q==",
+      "version": "20.11.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.7.tgz",
+      "integrity": "sha512-GPmeN1C3XAyV5uybAf4cMLWT9fDWcmQhZVtMFu7OR32WjrqGG+Wnk2V1d0bmtUyE/Zy1QJ9BxyiTih9z8Oks8A==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1516,9 +1516,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
@@ -2223,12 +2223,12 @@
       ],
       "license": "ISC",
       "dependencies": {
-        "@types/node": "^20.11.6",
+        "@types/node": "^20.11.7",
         "@types/yargs": "^17.0.32",
         "camelcase": "^8.0.0",
         "goodrouter": "^2.1.2",
         "jns42-generator": "^0.12.10",
-        "oa42-lib": "^0.6.4",
+        "oa42-lib": "^0.7.0",
         "schema-oas-v3-0": "^0.0.0",
         "schema-oas-v3-1": "^0.0.0",
         "schema-swagger-v2": "^0.0.0",
@@ -2247,10 +2247,10 @@
       }
     },
     "packages/ts/oa42-lib": {
-      "version": "0.6.4",
+      "version": "0.7.0",
       "license": "ISC",
       "dependencies": {
-        "@types/node": "^20.11.6",
+        "@types/node": "^20.11.7",
         "tslib": "^2.6.2",
         "type-fest": "^4.10.1"
       },
@@ -2263,7 +2263,7 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
-        "@types/node": "^20.11.0"
+        "@types/node": "^20.11.7"
       },
       "devDependencies": {
         "@tsconfig/node20": "^20.1.2",
@@ -2274,7 +2274,7 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
-        "@types/node": "^20.11.0"
+        "@types/node": "^20.11.7"
       },
       "devDependencies": {
         "@tsconfig/node20": "^20.1.2",
@@ -2285,7 +2285,7 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
-        "@types/node": "^20.11.0"
+        "@types/node": "^20.11.7"
       },
       "devDependencies": {
         "@tsconfig/node20": "^20.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2215,7 +2215,7 @@
       }
     },
     "packages/ts/oa42-generator": {
-      "version": "0.1.6",
+      "version": "0.2.0",
       "bundleDependencies": [
         "schema-oas-v3-0",
         "schema-oas-v3-1",

--- a/packages/ts/oa42-generator/package.json
+++ b/packages/ts/oa42-generator/package.json
@@ -36,12 +36,12 @@
     "generator"
   ],
   "dependencies": {
-    "@types/node": "^20.11.6",
+    "@types/node": "^20.11.7",
     "@types/yargs": "^17.0.32",
     "camelcase": "^8.0.0",
     "goodrouter": "^2.1.2",
     "jns42-generator": "^0.12.10",
-    "oa42-lib": "^0.6.4",
+    "oa42-lib": "^0.7.0",
     "schema-oas-v3-0": "^0.0.0",
     "schema-oas-v3-1": "^0.0.0",
     "schema-swagger-v2": "^0.0.0",
@@ -56,11 +56,6 @@
     "typescript": "^5.3.3"
   },
   "bundledDependencies": [
-    "schema-oas-v3-0",
-    "schema-oas-v3-1",
-    "schema-swagger-v2"
-  ],
-  "bundleDependencies": [
     "schema-oas-v3-0",
     "schema-oas-v3-1",
     "schema-swagger-v2"

--- a/packages/ts/oa42-generator/package.json
+++ b/packages/ts/oa42-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oa42-generator",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "sideEffects": false,
   "description": "",
   "type": "module",

--- a/packages/ts/oa42-generator/src/documents/oas30/document.ts
+++ b/packages/ts/oa42-generator/src/documents/oas30/document.ts
@@ -384,7 +384,7 @@ export class Document extends DocumentBase<oas.SchemaDocument> {
         document.components?.responses ?? {},
       )) {
         if (oas.isReference(responseObject)) {
-          throw "TODO";
+          continue;
         }
 
         yield* selectFromResponse(
@@ -444,7 +444,7 @@ export class Document extends DocumentBase<oas.SchemaDocument> {
 
       for (const [response, responseObject] of Object.entries(operationObject.responses ?? {})) {
         if (oas.isReference(responseObject)) {
-          throw "TODO";
+          continue;
         }
 
         assert(oas.isResponse(responseObject));

--- a/packages/ts/oa42-generator/src/generators/bodies/client-operation.ts
+++ b/packages/ts/oa42-generator/src/generators/bodies/client-operation.ts
@@ -229,7 +229,7 @@ function* generateResponseStatusCodeCaseClauses(
 
   yield itt`
     default:
-      throw new lib.Unreachable();
+      throw new lib.UnexpectedClientResponseStatusCode();
   `;
 }
 
@@ -320,7 +320,7 @@ function* generateOperationResultContentTypeCaseClauses(
 
   yield itt`
     default:
-      throw new lib.Unreachable();       
+      throw new lib.UnexpectedClientResponseContentType();       
   `;
 }
 

--- a/packages/ts/oa42-generator/src/generators/bodies/client-operation.ts
+++ b/packages/ts/oa42-generator/src/generators/bodies/client-operation.ts
@@ -229,7 +229,7 @@ function* generateResponseStatusCodeCaseClauses(
 
   yield itt`
     default:
-      throw new lib.UnexpectedClientResponseStatusCode();
+      throw new lib.ClientResponseUnexpectedStatusCode();
   `;
 }
 
@@ -294,7 +294,7 @@ function* generateOperationResultBody(
   } else {
     yield itt`
       if (responseContentType == null) {
-        throw new lib.MissingClientResponseContentType();
+        throw new lib.ClientResponseMissingContentType();
       }
 
       switch(responseContentType) {
@@ -320,7 +320,7 @@ function* generateOperationResultContentTypeCaseClauses(
 
   yield itt`
     default:
-      throw new lib.UnexpectedClientResponseContentType();       
+      throw new lib.ClientResponseUnexpectedContentType();       
   `;
 }
 

--- a/packages/ts/oa42-generator/src/generators/bodies/is-authentication.ts
+++ b/packages/ts/oa42-generator/src/generators/bodies/is-authentication.ts
@@ -1,12 +1,30 @@
 import * as models from "../../models/index.js";
-import { itt } from "../../utils/index.js";
+import { itt, joinIterable, toCamel } from "../../utils/index.js";
 
 export function* generateIsAuthenticationFunctionBody(
   pathModel: models.Path,
   operationModel: models.Operation,
 ) {
-  yield itt`
-    // TODO
-    return true;
-  `;
+  yield itt`return ${joinIterable(generateOrRules(operationModel.authenticationRequirements), " ||\n")}`;
+  return;
+}
+
+function* generateOrRules(requirements: models.AuthenticationRequirement[][]) {
+  if (requirements.length === 0) {
+    yield itt`true`;
+  }
+
+  for (const subRequirements of requirements) {
+    yield joinIterable(generateAndRules(subRequirements), " && ");
+  }
+}
+
+function* generateAndRules(subRequirements: models.AuthenticationRequirement[]) {
+  if (subRequirements.length === 0) {
+    yield itt`true`;
+  }
+
+  for (const requirement of subRequirements) {
+    yield itt`authentication.${toCamel(requirement.authenticationName)} !== undefined`;
+  }
 }

--- a/packages/ts/oa42-generator/src/generators/bodies/route-handler-method.ts
+++ b/packages/ts/oa42-generator/src/generators/bodies/route-handler-method.ts
@@ -192,7 +192,7 @@ export function* generateRouteHandlerMethodBody(
   } else {
     yield itt`
       if(requestContentType == null) {
-        throw new lib.MissingServerRequestContentType();
+        throw new lib.ServerRequestMissingContentType();
       }
 
       switch(requestContentType) {
@@ -242,7 +242,7 @@ function* generateRequestContentTypeCodeCaseClauses(
   }
   yield itt`
     default:
-      throw new lib.UnexpectedServerRequestContentType();
+      throw new lib.ServerRequestUnexpectedContentType();
   `;
 }
 

--- a/packages/ts/oa42-generator/src/generators/bodies/route-handler-method.ts
+++ b/packages/ts/oa42-generator/src/generators/bodies/route-handler-method.ts
@@ -60,13 +60,16 @@ export function* generateRouteHandlerMethodBody(
    */
 
   yield itt`
-    const authentication = {
-      ${authenticationNames.map(
-        (name) => itt`
-    ${toCamel(name)}: this.${toCamel(name, "authentication", "handler")}?.(""),
-    `,
-      )}
-    }
+    const authentication: A = Object.fromEntries(
+      await Promise.all([
+        ${authenticationNames.map(
+          (name) => itt`
+            (async () => [${JSON.stringify(toCamel(name))}, await this.${toCamel(name, "authentication", "handler")}?.("")])(),
+          `,
+        )}
+      ]),
+    );
+
     if(!${isOperationAuthenticationName}(authentication)) {
       throw new lib.AuthenticationFailed();
     }

--- a/packages/ts/oa42-generator/src/generators/files/client-ts.ts
+++ b/packages/ts/oa42-generator/src/generators/files/client-ts.ts
@@ -73,7 +73,7 @@ export function* generateClientTsCode(apiModel: models.Api) {
           ${generateClientOperationFunctionBody(apiModel, pathModel, operationModel)}
         }
       `;
-      yield* generateOperationCredentialsType(operationModel);
+      yield* generateOperationCredentialsType(apiModel, operationModel);
       yield* generateOperationOutgoingRequestType(apiModel, operationModel);
       yield* generateOperationIncomingResponseType(apiModel, operationModel);
     }

--- a/packages/ts/oa42-generator/src/generators/files/client-ts.ts
+++ b/packages/ts/oa42-generator/src/generators/files/client-ts.ts
@@ -4,6 +4,7 @@ import { banner, toCamel, toPascal } from "../../utils/index.js";
 import { itt } from "../../utils/iterable-text-template.js";
 import { generateClientOperationFunctionBody } from "../bodies/index.js";
 import {
+  generateOperationCredentialsType,
   generateOperationIncomingResponseType,
   generateOperationOutgoingRequestType,
 } from "../types/index.js";
@@ -47,10 +48,9 @@ export function* generateClientTsCode(apiModel: models.Api) {
   for (const pathModel of apiModel.paths) {
     for (const operationModel of pathModel.operations) {
       const operationFunctionName = toCamel(operationModel.name);
-
       const operationOutgoingRequestName = toPascal(operationModel.name, "outgoing", "request");
-
       const operationIncomingResponseName = toPascal(operationModel.name, "incoming", "response");
+      const credentialsName = toPascal(operationModel.name, "credentials");
 
       const jsDoc = [
         operationModel.deprecated ? "@deprecated" : "",
@@ -67,12 +67,13 @@ export function* generateClientTsCode(apiModel: models.Api) {
          */
         export async function ${operationFunctionName}(
           outgoingRequest: ${operationOutgoingRequestName},
-          credentials: unknown,
+          credentials: ${credentialsName},
           options: ClientOptions = defaultClientOptions,
         ): Promise<${operationIncomingResponseName}> {
           ${generateClientOperationFunctionBody(apiModel, pathModel, operationModel)}
         }
       `;
+      yield* generateOperationCredentialsType(operationModel);
       yield* generateOperationOutgoingRequestType(apiModel, operationModel);
       yield* generateOperationIncomingResponseType(apiModel, operationModel);
     }

--- a/packages/ts/oa42-generator/src/generators/files/server-ts.ts
+++ b/packages/ts/oa42-generator/src/generators/files/server-ts.ts
@@ -54,7 +54,9 @@ export function* generateServerTsCode(apiModel: models.Api) {
 
     yield itt`
       export type ${handlerTypeName}<A extends ServerAuthentication> =
-        (credential: string) => A[${JSON.stringify(toCamel(authenticationModel.name))}] | Promise<A[${JSON.stringify(toCamel(authenticationModel.name))}]>;
+        (credential: string) =>
+          A[${JSON.stringify(toCamel(authenticationModel.name))}] | undefined |
+          Promise<A[${JSON.stringify(toCamel(authenticationModel.name))}] | undefined>;
     `;
   }
 

--- a/packages/ts/oa42-generator/src/generators/types/client-credentials.ts
+++ b/packages/ts/oa42-generator/src/generators/types/client-credentials.ts
@@ -1,0 +1,34 @@
+import * as models from "../../models/index.js";
+import { joinIterable } from "../../utils/index.js";
+import { itt } from "../../utils/iterable-text-template.js";
+import { toCamel, toPascal } from "../../utils/name.js";
+
+export function* generateOperationCredentialsType(operationModel: models.Operation) {
+  const operationCredentialsName = toPascal(operationModel.name, "credentials");
+
+  yield itt`
+    export type ${operationCredentialsName} =
+      ${joinIterable(generateUnionTypes(operationModel.authenticationRequirements), " |\n")}
+    ;
+  `;
+}
+
+function* generateUnionTypes(requirements: models.AuthenticationRequirement[][]) {
+  if (requirements.length === 0) {
+    yield itt`{}`;
+  }
+
+  for (const subRequirements of requirements) {
+    yield itt`
+      {
+        ${generateTypeBody(subRequirements)}
+      }
+    `;
+  }
+}
+
+function* generateTypeBody(subRequirements: models.AuthenticationRequirement[]) {
+  for (const requirement of subRequirements) {
+    yield itt`${toCamel(requirement.authenticationName)}: string,`;
+  }
+}

--- a/packages/ts/oa42-generator/src/generators/types/index.ts
+++ b/packages/ts/oa42-generator/src/generators/types/index.ts
@@ -1,3 +1,4 @@
+export * from "./client-credentials.js";
 export * from "./operation-authentication.js";
 export * from "./operation-handler.js";
 export * from "./operation-incoming-request.js";

--- a/packages/ts/oa42-lib/package.json
+++ b/packages/ts/oa42-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oa42-lib",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "",
   "type": "module",
   "main": "./out/main.js",
@@ -37,7 +37,7 @@
     "library"
   ],
   "dependencies": {
-    "@types/node": "^20.11.6",
+    "@types/node": "^20.11.7",
     "tslib": "^2.6.2",
     "type-fest": "^4.10.1"
   },

--- a/packages/ts/oa42-lib/src/errors/client.ts
+++ b/packages/ts/oa42-lib/src/errors/client.ts
@@ -24,6 +24,14 @@ export class UnexpectedClientResponseContentType extends ClientError {
   }
 }
 
+export class UnexpectedClientResponseStatusCode extends ClientError {
+  public readonly name = "UnexpectedClientResponseStatusCode";
+
+  constructor() {
+    super(`Unexpected status code in client response`);
+  }
+}
+
 export class ClientRequestParameterValidationFailed extends ClientError {
   public readonly name = "ClientRequestParameterValidationFailed";
 

--- a/packages/ts/oa42-lib/src/errors/client.ts
+++ b/packages/ts/oa42-lib/src/errors/client.ts
@@ -8,24 +8,24 @@ export abstract class ClientError extends ErrorBase {
   //
 }
 
-export class MissingClientResponseContentType extends ClientError {
-  public readonly name = "MissingClientResponseContentType";
+export class ClientResponseMissingContentType extends ClientError {
+  public readonly name = "ClientResponseMissingContentType";
 
   constructor() {
     super(`Missing content-type in client response`);
   }
 }
 
-export class UnexpectedClientResponseContentType extends ClientError {
-  public readonly name = "UnexpectedClientResponseContentType";
+export class ClientResponseUnexpectedContentType extends ClientError {
+  public readonly name = "ClientResponseUnexpectedContentType";
 
   constructor() {
     super(`Unexpected content-type in client response`);
   }
 }
 
-export class UnexpectedClientResponseStatusCode extends ClientError {
-  public readonly name = "UnexpectedClientResponseStatusCode";
+export class ClientResponseUnexpectedStatusCode extends ClientError {
+  public readonly name = "ClientResponseUnexpectedStatusCode";
 
   constructor() {
     super(`Unexpected status code in client response`);

--- a/packages/ts/oa42-lib/src/errors/server.ts
+++ b/packages/ts/oa42-lib/src/errors/server.ts
@@ -40,16 +40,16 @@ export class OperationNotImplemented extends ServerError {
   }
 }
 
-export class MissingServerRequestContentType extends ServerError {
-  public readonly name = "MissingServerRequestContentType";
+export class ServerRequestMissingContentType extends ServerError {
+  public readonly name = "ServerRequestMissingContentType";
 
   constructor() {
     super(`Missing content-type in server request`);
   }
 }
 
-export class UnexpectedServerRequestContentType extends ServerError {
-  public readonly name = "UnexpectedServerRequestContentType";
+export class ServerRequestUnexpectedContentType extends ServerError {
+  public readonly name = "ServerRequestUnexpectedContentType";
 
   constructor() {
     super(`Unexpected content-type in server request`);

--- a/packages/ts/oa42-lib/src/server-middleware/error.ts
+++ b/packages/ts/oa42-lib/src/server-middleware/error.ts
@@ -41,8 +41,8 @@ export function createErrorMiddleware(onError?: (error: unknown) => void): Serve
       }
 
       if (
-        error instanceof errors.MissingServerRequestContentType ||
-        error instanceof errors.UnexpectedServerRequestContentType
+        error instanceof errors.ServerRequestMissingContentType ||
+        error instanceof errors.ServerRequestUnexpectedContentType
       ) {
         return {
           headers: {},

--- a/packages/ts/schema-oas-v3-0/package.json
+++ b/packages/ts/schema-oas-v3-0/package.json
@@ -33,10 +33,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@types/node": "^20.11.0"
+    "@types/node": "^20.11.7"
   },
   "devDependencies": {
-    "typescript": "^5.3.3",
-    "@tsconfig/node20": "^20.1.2"
+    "@tsconfig/node20": "^20.1.2",
+    "typescript": "^5.3.3"
   }
 }

--- a/packages/ts/schema-oas-v3-1/package.json
+++ b/packages/ts/schema-oas-v3-1/package.json
@@ -33,10 +33,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@types/node": "^20.11.0"
+    "@types/node": "^20.11.7"
   },
   "devDependencies": {
-    "typescript": "^5.3.3",
-    "@tsconfig/node20": "^20.1.2"
+    "@tsconfig/node20": "^20.1.2",
+    "typescript": "^5.3.3"
   }
 }

--- a/packages/ts/schema-swagger-v2/package.json
+++ b/packages/ts/schema-swagger-v2/package.json
@@ -33,10 +33,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@types/node": "^20.11.0"
+    "@types/node": "^20.11.7"
   },
   "devDependencies": {
-    "typescript": "^5.3.3",
-    "@tsconfig/node20": "^20.1.2"
+    "@tsconfig/node20": "^20.1.2",
+    "typescript": "^5.3.3"
   }
 }


### PR DESCRIPTION
- [x] implement authentication check
- [x] implement client credential type
- [x] run authentication handlers in parallel
- [x] debugging
- [x] update tests
- [x] release lib
- [x] release generator


errors now have a better structure, for example: `ClientResponseContentTypeMissing`. The first part is `Client` or `Server`, depending on who generate the error then it's `Request` or `Response` and then the kind of error.



- fixes https://github.com/LuvDaSun/OpenApi42/issues/20
- fixes https://github.com/LuvDaSun/OpenApi42/issues/9

