### PR TITLE
Implementing http and api key security schema

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,6 +1,18 @@
 {
   "version": "0.2",
-  "words": ["AZAZ", "camelcase", "endregion", "goodrouter", "Promisable", "urlencoding"],
+  "words": [
+    "AZAZ",
+    "camelcase",
+    "elmerbulthuis",
+    "endregion",
+    "esbenp",
+    "goodrouter",
+    "Promisable",
+    "urlencoding",
+    "welkom"
+  ],
   "useGitignore": true,
-  "files": ["packages/ts/oa42-generator/src/**", "packages/ts/oa42-lib/src/**"]
+  "files": ["**"],
+  "ignorePaths": ["specifications/"],
+  "enableFiletypes": ["*"]
 }

--- a/fixtures/specifications/test30.yaml
+++ b/fixtures/specifications/test30.yaml
@@ -1,0 +1,75 @@
+openapi: 3.0.0
+
+info:
+  title: Test api
+  description: |-
+    For testing purpose!
+  version: 0.1.0
+
+paths:
+  /api-key-header:
+    get:
+      security:
+        - api-key-header: []
+      operationId: api-key-header
+      summary: Test endpoint
+      responses:
+        "204":
+          description: No content
+  /api-key-cookie:
+    get:
+      security:
+        - api-key-header: []
+      operationId: api-key-cookie
+      summary: Test endpoint
+      responses:
+        "204":
+          description: No content
+  /api-key-query:
+    get:
+      security:
+        - api-key-header: []
+      operationId: api-key-query
+      summary: Test endpoint
+      responses:
+        "204":
+          description: No content
+  /http-basic:
+    get:
+      security:
+        - http-basic: []
+      operationId: http-basic
+      summary: Test endpoint
+      responses:
+        "204":
+          description: No content
+  /http-bearer:
+    get:
+      security:
+        - http-bearer: []
+      operationId: http-bearer
+      summary: Test endpoint
+      responses:
+        "204":
+          description: No content
+
+components:
+  securitySchemes:
+    api-key-header:
+      type: apiKey
+      name: api-key-header
+      in: header
+    api-key-cookie:
+      type: apiKey
+      name: api-key-cookie
+      in: cookie
+    api-key-query:
+      type: apiKey
+      name: api-key-query
+      in: query
+    http-basic:
+      type: http
+      scheme: basic
+    http-bearer:
+      type: http
+      scheme: bearer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1516,6 +1516,11 @@
         "jns42-generator": "bin/jns42-generator"
       }
     },
+    "node_modules/js-base64": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.6.tgz",
+      "integrity": "sha512-NPrWuHFxFUknr1KqJRDgUQPexQF0uIJWjeT+2KjEePhitQxQEx5EJBG1lVn5/hc8aLycTpXrDOgPQ6Zq+EDiTA=="
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2250,6 +2255,7 @@
       "license": "ISC",
       "dependencies": {
         "@types/node": "^20.11.10",
+        "js-base64": "^3.7.6",
         "tslib": "^2.6.2",
         "type-fest": "^4.10.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2235,7 +2235,7 @@
         "camelcase": "^8.0.0",
         "goodrouter": "^2.1.2",
         "jns42-generator": "^0.13.2",
-        "oa42-lib": "^0.7.0",
+        "oa42-lib": "^0.7.1",
         "tslib": "^2.6.2",
         "type-fest": "^4.10.1",
         "typescript": "^5.3.3",
@@ -2251,7 +2251,7 @@
       }
     },
     "packages/ts/oa42-lib": {
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "ISC",
       "dependencies": {
         "@types/node": "^20.11.10",

--- a/packages/ts/oa42-generator/package.json
+++ b/packages/ts/oa42-generator/package.json
@@ -42,7 +42,7 @@
     "camelcase": "^8.0.0",
     "goodrouter": "^2.1.2",
     "jns42-generator": "^0.13.2",
-    "oa42-lib": "^0.7.0",
+    "oa42-lib": "^0.7.1",
     "tslib": "^2.6.2",
     "type-fest": "^4.10.1",
     "typescript": "^5.3.3",

--- a/packages/ts/oa42-generator/src/documents/oas30/document.ts
+++ b/packages/ts/oa42-generator/src/documents/oas30/document.ts
@@ -212,10 +212,52 @@ export class Document extends DocumentBase<oas.SchemaDocument> {
     authenticationName: string,
     authenticationItem: oas.SecurityScheme,
   ) {
-    const authenticationModel: models.Authentication = {
-      name: authenticationName,
-    };
-    return authenticationModel;
+    switch (authenticationItem.type) {
+      case "apiKey": {
+        const authenticationModel: models.ApiKeyAuthentication = {
+          name: authenticationName,
+          type: "apiKey",
+          in: authenticationItem.in,
+        };
+        return authenticationModel;
+      }
+      case "http":
+        switch (authenticationItem.scheme) {
+          case "basic": {
+            const authenticationModel: models.HttpBasicAuthentication = {
+              name: authenticationName,
+              type: "http",
+              scheme: "basic",
+            };
+            return authenticationModel;
+          }
+
+          case "bearer": {
+            const authenticationModel: models.HttpBearerAuthentication = {
+              name: authenticationName,
+              type: "http",
+              scheme: "bearer",
+            };
+            return authenticationModel;
+          }
+
+          default: {
+            throw new Error("http authentication scheme not yet supported");
+          }
+        }
+
+      case "oauth2": {
+        throw new Error("security scheme oauth2 not yet supported");
+      }
+
+      case "openIdConnect": {
+        throw new Error("security scheme openIdConnect not yet supported");
+      }
+
+      default: {
+        throw new Error("security scheme not supported");
+      }
+    }
   }
 
   private *getOperationResultModels(operationUri: URL, operationItem: oas.Operation) {

--- a/packages/ts/oa42-generator/src/documents/oas30/document.ts
+++ b/packages/ts/oa42-generator/src/documents/oas30/document.ts
@@ -170,7 +170,9 @@ export class Document extends DocumentBase<oas.SchemaDocument> {
     const mockable =
       [...pathParameters, ...headerParameters, ...queryParameters, ...cookieParameters].every(
         (parameterModel) => parameterModel.mockable || !parameterModel.required,
-      ) && operationResults.some((operationResultModel) => operationResultModel.mockable);
+      ) &&
+      (operationResults.length == 0 ||
+        operationResults.some((operationResultModel) => operationResultModel.mockable));
 
     const operationModel: models.Operation = {
       uri: operationUri,
@@ -297,7 +299,8 @@ export class Document extends DocumentBase<oas.SchemaDocument> {
     const mockable =
       headerParameters.every(
         (parameterModel) => parameterModel.mockable || !parameterModel.required,
-      ) && bodies.some((bodyModel) => bodyModel.mockable);
+      ) &&
+      (bodies.length == 0 || bodies.some((bodyModel) => bodyModel.mockable));
 
     return {
       uri: responseUri,

--- a/packages/ts/oa42-generator/src/generators/bodies/route-handler-method.ts
+++ b/packages/ts/oa42-generator/src/generators/bodies/route-handler-method.ts
@@ -74,7 +74,7 @@ export function* generateRouteHandlerMethodBody(
             (
               async () => [
                 ${JSON.stringify(toCamel(authenticationModel.name))},
-                credentials.apiToken == null ?
+                credentials.${toCamel(authenticationModel.name)} == null ?
                   undefined :
                   await this.${toCamel(authenticationModel.name, "authentication", "handler")}?.(credentials.${toCamel(authenticationModel.name)})
               ]
@@ -281,14 +281,14 @@ export function* generateRouteHandlerMethodBody(
             case "basic":
               yield itt`
                 ${toCamel(authenticationModel.name)}:
-                  lib.parseBasicAuthorizationHeader(lib.getParameterValues(serverIncomingRequest.headers, ${JSON.stringify(authenticationModel.name)})),
+                  lib.parseBasicAuthorizationHeader(lib.getParameterValues(serverIncomingRequest.headers, "authorization")),
               `;
               break;
 
             case "bearer":
               yield itt`
                 ${toCamel(authenticationModel.name)}:
-                  lib.parseAuthorizationHeader("bearer", serverIncomingRequest.headers, ${JSON.stringify(authenticationModel.name)})),
+                  lib.parseAuthorizationHeader("bearer", lib.getParameterValues(serverIncomingRequest.headers, "authorization")),
               `;
               break;
 

--- a/packages/ts/oa42-generator/src/generators/files/client-server-test-ts.ts
+++ b/packages/ts/oa42-generator/src/generators/files/client-server-test-ts.ts
@@ -161,9 +161,43 @@ function* generateOperationTest(
         authenticationModel.name,
         "authentication",
       );
-      yield itt`
-        server.${registerAuthenticationHandlerMethodName}((credential) => credential === "super-secret-api-key")
-      `;
+      switch (authenticationModel.type) {
+        case "apiKey":
+          yield itt`
+            server.${registerAuthenticationHandlerMethodName}(
+              (credential) => credential === "super-secret-api-key"
+            )
+          `;
+          break;
+        case "http":
+          switch (authenticationModel.scheme) {
+            case "basic":
+              yield itt`
+                server.${registerAuthenticationHandlerMethodName}(
+                  (credential) =>
+                    credential.id === "elmerbulthuis" && credential.password === "welkom123"
+                )
+              `;
+              break;
+
+            case "bearer":
+              yield itt`
+                server.${registerAuthenticationHandlerMethodName}(
+                  (credential) => credential === "super-secret-api-key"
+                )
+              `;
+              break;
+
+            default: {
+              throw "impossible";
+            }
+          }
+          break;
+
+        default: {
+          throw "impossible";
+        }
+      }
     }
     yield itt`
       let lastError: unknown;

--- a/packages/ts/oa42-generator/src/generators/types/client-credentials.ts
+++ b/packages/ts/oa42-generator/src/generators/types/client-credentials.ts
@@ -27,20 +27,26 @@ function* generateTypeContent(authenticationModels: Iterable<models.Authenticati
   for (const authenticationModel of authenticationModels) {
     switch (authenticationModel.type) {
       case "apiKey":
-        yield itt`${toCamel(authenticationModel.name)}: string,`;
+        yield itt`
+          ${toCamel(authenticationModel.name)}: string,
+        `;
         break;
 
       case "http":
         switch (authenticationModel.scheme) {
           case "basic":
-            yield itt`${toCamel(authenticationModel.name)}: {
-              id: string,
-              password: string,
-            },`;
+            yield itt`
+              ${toCamel(authenticationModel.name)}: {
+                id: string,
+                password: string,
+              },
+            `;
             break;
 
           case "bearer":
-            yield itt`${toCamel(authenticationModel.name)}: string,`;
+            yield itt`
+              ${toCamel(authenticationModel.name)}: string,
+            `;
             break;
 
           default: {

--- a/packages/ts/oa42-generator/src/generators/types/client-credentials.ts
+++ b/packages/ts/oa42-generator/src/generators/types/client-credentials.ts
@@ -18,11 +18,40 @@ export function* generateOperationCredentialsType(
 
   yield itt`
     export type ${operationCredentialsName} = {
-      ${authenticationModels.map(
-        (authenticationModel) => itt`
-          ${toCamel(authenticationModel.name)}: string,
-        `,
-      )}
+      ${generateTypeContent(authenticationModels)}
     };
   `;
+}
+
+function* generateTypeContent(authenticationModels: Iterable<models.Authentication>) {
+  for (const authenticationModel of authenticationModels) {
+    switch (authenticationModel.type) {
+      case "apiKey":
+        yield itt`${toCamel(authenticationModel.name)}: string,`;
+        break;
+
+      case "http":
+        switch (authenticationModel.scheme) {
+          case "basic":
+            yield itt`${toCamel(authenticationModel.name)}: {
+              id: string,
+              password: string,
+            },`;
+            break;
+
+          case "bearer":
+            yield itt`${toCamel(authenticationModel.name)}: string,`;
+            break;
+
+          default: {
+            throw "impossible";
+          }
+        }
+        break;
+
+      default: {
+        throw "impossible";
+      }
+    }
+  }
 }

--- a/packages/ts/oa42-generator/src/models/authentication.ts
+++ b/packages/ts/oa42-generator/src/models/authentication.ts
@@ -1,3 +1,22 @@
-export interface Authentication {
+export type Authentication =
+  | ApiKeyAuthentication
+  | HttpBasicAuthentication
+  | HttpBearerAuthentication;
+
+export interface ApiKeyAuthentication {
   name: string;
+  type: "apiKey";
+  in: "query" | "header" | "cookie";
+}
+
+export interface HttpBasicAuthentication {
+  name: string;
+  type: "http";
+  scheme: "basic";
+}
+
+export interface HttpBearerAuthentication {
+  name: string;
+  type: "http";
+  scheme: "bearer";
 }

--- a/packages/ts/oa42-lib/package.json
+++ b/packages/ts/oa42-lib/package.json
@@ -37,6 +37,7 @@
   ],
   "dependencies": {
     "@types/node": "^20.11.10",
+    "js-base64": "^3.7.6",
     "tslib": "^2.6.2",
     "type-fest": "^4.10.1"
   },

--- a/packages/ts/oa42-lib/package.json
+++ b/packages/ts/oa42-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oa42-lib",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "",
   "type": "module",
   "main": "./out/main.js",

--- a/packages/ts/oa42-lib/src/utils/headers.test.ts
+++ b/packages/ts/oa42-lib/src/utils/headers.test.ts
@@ -1,0 +1,14 @@
+import assert from "assert";
+import test from "node:test";
+import { parseAcceptHeader } from "./headers.js";
+
+test("accept", async (t) => {
+  {
+    const actual = parseAcceptHeader(
+      ["text/html; q=0.1, application/octet-stream", "text/plain"],
+      new Set(["application/octet-stream", "text/plain", "text/html"]),
+    );
+    const expected = ["application/octet-stream", "text/plain", "text/html"];
+    assert.deepEqual(actual, expected);
+  }
+});

--- a/packages/ts/oa42-lib/src/utils/headers.ts
+++ b/packages/ts/oa42-lib/src/utils/headers.ts
@@ -1,0 +1,102 @@
+import { Base64 } from "js-base64";
+
+export function parseAuthorizationHeader(scheme: string, values: Iterable<string>) {
+  const prefix = scheme + " ";
+
+  for (const value of values) {
+    if (value.toLowerCase().startsWith(prefix.toLowerCase())) {
+      return value.substring(prefix.length);
+    }
+  }
+}
+
+export function stringifyAuthorizationHeader(scheme: string, value: string) {
+  const prefix = scheme + " ";
+
+  return prefix + value;
+}
+
+export function parseBasicAuthorizationHeader(values: Iterable<string>) {
+  const encoded = parseAuthorizationHeader("Basic", values);
+
+  if (encoded == null) return;
+
+  const decoded = Base64.decode(encoded);
+  const [id, password] = decoded.split(":", 2);
+
+  return { id, password };
+}
+
+export function stringifyBasicAuthorizationHeader(credential: { id: string; password: string }) {
+  const { id, password } = credential;
+
+  const decoded = id + ":" + password;
+  const encoded = Base64.encode(decoded);
+
+  return stringifyAuthorizationHeader("Basic", encoded);
+}
+
+export function* parseContentTypeHeader(values: Iterable<string>) {
+  for (const value of values) {
+    const parts = value.split(";");
+    yield parts[0];
+  }
+}
+
+export function parseAcceptHeader<T extends string>(values: string[], types: Set<T>) {
+  const parsed = parse();
+  const list = Array.from(parsed);
+  list.sort(([, a], [, b]) => b - a);
+  return list.map(([type]) => type);
+
+  function* parse() {
+    for (const header of values) {
+      const entries = header.split(/\s*,\s*/);
+
+      for (const entry of entries) {
+        const parts = entry.split(/\s*;\s*/);
+        const type = parts.shift() as T | undefined;
+
+        if (!type) continue;
+        if (!types.has(type)) continue;
+
+        const values: Record<string, string> = {};
+        for (const part of parts) {
+          const pair = part.split(/\s*=\s*/, 2);
+          if (pair.length !== 2) continue;
+
+          const [key, value] = pair;
+          values[key] = value;
+        }
+        if ("q" in values) {
+          const q = parseFloat(values["q"]);
+
+          if (isNaN(q)) {
+            continue;
+          }
+
+          if (q <= 0) {
+            continue;
+          }
+
+          if (q > 1) {
+            yield [type, 1] as const;
+            continue;
+          }
+
+          yield [type, q] as const;
+          continue;
+        }
+
+        yield [type, 1] as const;
+        continue;
+      }
+    }
+  }
+}
+
+export function stringifyAcceptHeader<T extends string>(types: Iterable<T>) {
+  const typesArray = Array.from(types);
+
+  return typesArray.map((type, index) => `${type}; q=${1 - index / typesArray.length}`).join(", ");
+}

--- a/packages/ts/oa42-lib/src/utils/index.ts
+++ b/packages/ts/oa42-lib/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./functional.js";
+export * from "./headers.js";
 export * from "./method.js";
 export * from "./parameters.js";
 export * from "./status-code.js";


### PR DESCRIPTION
Support different kinds of security schemes. And properly implement the api key and basic and bearer http security scheme.

improves mock generation

improves spelling config

- [x] read the schemes into the api model
- [x] switch between schemes in generator code
- [x] test

- fixes #32 
- fixes #25 
- fixes #26 