### PR TITLE
not require parameters in request or response when they may be empty

### DIFF
--- a/packages/npm/oa42-generator/src/generators/functions/client-operation.ts
+++ b/packages/npm/oa42-generator/src/generators/functions/client-operation.ts
@@ -89,7 +89,7 @@ function* generateBody(
 
   yield itt`
     if(validateOutgoingParameters) {
-      if(!parameters.${isRequestParametersFunction}(outgoingRequest.parameters)) {
+      if(!parameters.${isRequestParametersFunction}(outgoingRequest.parameters ?? {})) {
         const lastError = parameters.getLastParameterValidationError();
         throw new lib.ClientRequestParameterValidationFailed(
           lastError.parameterName,

--- a/packages/npm/oa42-generator/src/generators/functions/endpoint-handler-method.ts
+++ b/packages/npm/oa42-generator/src/generators/functions/endpoint-handler-method.ts
@@ -492,7 +492,7 @@ function* generateOperationResultBody(
 
   yield itt`
     if(validateOutgoingParameters) {
-      if(!parameters.${isResponseParametersFunction}(outgoingResponse.parameters)) {
+      if(!parameters.${isResponseParametersFunction}(outgoingResponse.parameters ?? {})) {
         const lastError = parameters.getLastParameterValidationError();
         throw new lib.ServerResponseParameterValidationFailed(
           lastError.parameterName,

--- a/packages/npm/oa42-generator/src/generators/types/operation-incoming-request.ts
+++ b/packages/npm/oa42-generator/src/generators/types/operation-incoming-request.ts
@@ -1,5 +1,5 @@
 import * as models from "../../models/index.js";
-import { joinIterable } from "../../utils/index.js";
+import { joinIterable, mapIterable } from "../../utils/index.js";
 import { itt } from "../../utils/iterable-text-template.js";
 import { getIncomingRequestTypeName, getRequestParametersTypeName } from "../names/index.js";
 
@@ -7,36 +7,49 @@ export function* generateOperationIncomingRequestType(
   apiModel: models.Api,
   operationModel: models.Operation,
 ) {
-  const operationIncomingRequestName = getIncomingRequestTypeName(operationModel);
+  const typeName = getIncomingRequestTypeName(operationModel);
 
   yield itt`
-    export type ${operationIncomingRequestName} = ${joinIterable(
-      generateRequestTypes(apiModel, operationModel),
+    export type ${typeName} = ${joinIterable(
+      mapIterable(generateElements(apiModel, operationModel), (element) => itt`(${element})`),
       " |\n",
     )};
   `;
 }
 
-function* generateRequestTypes(apiModel: models.Api, operationModel: models.Operation) {
+function* generateElements(apiModel: models.Api, operationModel: models.Operation) {
+  yield itt`
+    ${generateParametersContainerType(operationModel)} &
+    (
+      ${joinIterable(generateBodyContainerTypes(apiModel, operationModel), " |\n")}
+    )
+  `;
+}
+
+function* generateParametersContainerType(operationModel: models.Operation) {
+  const parametersTypeName = getRequestParametersTypeName(operationModel);
+
+  yield `lib.ParametersContainer<parameters.${parametersTypeName}>`;
+}
+
+function* generateBodyContainerTypes(apiModel: models.Api, operationModel: models.Operation) {
   if (operationModel.bodies.length === 0) {
-    yield* generateRequestBodies(apiModel, operationModel);
+    yield* generateBodyContainerType(apiModel, operationModel);
   }
 
   for (const bodyModel of operationModel.bodies) {
-    yield* generateRequestBodies(apiModel, operationModel, bodyModel);
+    yield* generateBodyContainerType(apiModel, operationModel, bodyModel);
   }
 }
 
-function* generateRequestBodies(
+function* generateBodyContainerType(
   apiModel: models.Api,
   operationModel: models.Operation,
   bodyModel?: models.Body,
 ) {
-  const operationIncomingParametersName = getRequestParametersTypeName(operationModel);
-
   if (bodyModel == null) {
     yield itt`
-      lib.IncomingEmptyRequest<parameters.${operationIncomingParametersName}>
+      lib.IncomingEmptyRequest
     `;
     return;
   }
@@ -45,7 +58,6 @@ function* generateRequestBodies(
     case "plain/text": {
       yield itt`
         lib.IncomingTextRequest<
-          parameters.${operationIncomingParametersName},
           ${JSON.stringify(bodyModel.contentType)}
         >
       `;
@@ -57,7 +69,6 @@ function* generateRequestBodies(
 
       yield itt`
         lib.IncomingJsonRequest<
-          parameters.${operationIncomingParametersName},
           ${JSON.stringify(bodyModel.contentType)},
           ${bodyTypeName == null ? "unknown" : itt`types.${bodyTypeName}`}
         >
@@ -67,7 +78,6 @@ function* generateRequestBodies(
     default: {
       yield itt`
         lib.IncomingStreamRequest<
-          parameters.${operationIncomingParametersName},
           ${JSON.stringify(bodyModel.contentType)}
         >
       `;

--- a/packages/npm/oa42-generator/src/generators/types/operation-outgoing-response.ts
+++ b/packages/npm/oa42-generator/src/generators/types/operation-outgoing-response.ts
@@ -1,5 +1,5 @@
 import * as models from "../../models/index.js";
-import { joinIterable } from "../../utils/index.js";
+import { joinIterable, mapIterable } from "../../utils/index.js";
 import { itt } from "../../utils/iterable-text-template.js";
 import { getOutgoingResponseTypeName, getResponseParametersTypeName } from "../names/index.js";
 
@@ -7,51 +7,73 @@ export function* generateOperationOutgoingResponseType(
   apiModel: models.Api,
   operationModel: models.Operation,
 ) {
-  const operationOutgoingResponseName = getOutgoingResponseTypeName(operationModel);
+  const typeName = getOutgoingResponseTypeName(operationModel);
 
   yield itt`
-    export type ${operationOutgoingResponseName} = ${joinIterable(
-      generateResponseTypes(apiModel, operationModel),
+    export type ${typeName} = ${joinIterable(
+      mapIterable(generateElements(apiModel, operationModel), (element) => itt`(${element})`),
       " |\n",
     )};
   `;
 }
 
-function* generateResponseTypes(apiModel: models.Api, operationModel: models.Operation) {
+function* generateElements(apiModel: models.Api, operationModel: models.Operation) {
   if (operationModel.operationResults.length === 0) {
     yield itt`never`;
   }
 
   for (const operationResultModel of operationModel.operationResults) {
-    if (operationResultModel.bodies.length === 0) {
-      yield* generateResponseBodies(apiModel, operationModel, operationResultModel);
-    }
-
-    for (const bodyModel of operationResultModel.bodies) {
-      yield* generateResponseBodies(apiModel, operationModel, operationResultModel, bodyModel);
-    }
+    yield itt`
+      ${generateParametersContainerType(operationModel, operationResultModel)} &
+      (
+        ${joinIterable(generateBodyContainerTypes(apiModel, operationModel, operationResultModel), " |\n")}
+      )
+    `;
   }
 }
 
-function* generateResponseBodies(
+function* generateParametersContainerType(
+  operationModel: models.Operation,
+  operationResultModel: models.OperationResult,
+) {
+  const parametersTypeName = getResponseParametersTypeName(operationModel, operationResultModel);
+
+  const required = operationResultModel.headerParameters.some((parameter) => parameter.required);
+
+  if (required) {
+    yield `lib.ParametersContainer<parameters.${parametersTypeName}>`;
+  } else {
+    yield `lib.OptionalParametersContainer<parameters.${parametersTypeName}>`;
+  }
+}
+
+function* generateBodyContainerTypes(
+  apiModel: models.Api,
+  operationModel: models.Operation,
+  operationResultModel: models.OperationResult,
+) {
+  if (operationResultModel.bodies.length === 0) {
+    yield* generateBodyContainerType(apiModel, operationModel, operationResultModel);
+  }
+
+  for (const bodyModel of operationResultModel.bodies) {
+    yield* generateBodyContainerType(apiModel, operationModel, operationResultModel, bodyModel);
+  }
+}
+
+function* generateBodyContainerType(
   apiModel: models.Api,
   operationModel: models.Operation,
   operationResultModel: models.OperationResult,
   bodyModel?: models.Body,
 ) {
-  const operationOutgoingParametersName = getResponseParametersTypeName(
-    operationModel,
-    operationResultModel,
-  );
-
   if (bodyModel == null) {
     yield itt`
       lib.OutgoingEmptyResponse<
         ${joinIterable(
           operationResultModel.statusCodes.map((statusCode) => JSON.stringify(statusCode)),
           " |\n",
-        )},
-        parameters.${operationOutgoingParametersName}
+        )}
       >
     `;
     return;
@@ -65,7 +87,6 @@ function* generateResponseBodies(
             operationResultModel.statusCodes.map((statusCode) => JSON.stringify(statusCode)),
             " |\n",
           )},
-          parameters.${operationOutgoingParametersName},
           ${JSON.stringify(bodyModel.contentType)}
         >
       `;
@@ -81,7 +102,6 @@ function* generateResponseBodies(
             operationResultModel.statusCodes.map((statusCode) => JSON.stringify(statusCode)),
             " |\n",
           )},
-          parameters.${operationOutgoingParametersName},
           ${JSON.stringify(bodyModel.contentType)},
           ${bodyTypeName == null ? "unknown" : itt`types.${bodyTypeName}`}
         >
@@ -95,7 +115,6 @@ function* generateResponseBodies(
             operationResultModel.statusCodes.map((statusCode) => JSON.stringify(statusCode)),
             " |\n",
           )},
-          parameters.${operationOutgoingParametersName},
           ${JSON.stringify(bodyModel.contentType)}
         >
       `;

--- a/packages/npm/oa42-lib/src/models/empty.ts
+++ b/packages/npm/oa42-lib/src/models/empty.ts
@@ -1,32 +1,35 @@
 import { StatusCode } from "../utils/index.js";
+import { ParametersContainer } from "./parameters.js";
 
-export interface OutgoingEmptyRequestDefault<P extends object> {
-  readonly parameters: P;
-}
+export type OutgoingEmptyRequestDefault<P extends object> = ParametersContainer<P>;
 
-export interface OutgoingEmptyRequest<P extends object> {
-  readonly parameters: P;
+export type OutgoingEmptyRequest<P extends object> = ParametersContainer<P> & {
   readonly contentType: null;
-}
+};
 
-export interface OutgoingEmptyResponseDefault<S extends StatusCode, P extends object> {
+export type OutgoingEmptyResponseDefault<
+  S extends StatusCode,
+  P extends object,
+> = ParametersContainer<P> & {
   readonly status: S;
-  readonly parameters: P;
-}
+};
 
-export interface OutgoingEmptyResponse<S extends StatusCode, P extends object> {
+export type OutgoingEmptyResponse<
+  S extends StatusCode,
+  P extends object,
+> = ParametersContainer<P> & {
   readonly status: S;
-  readonly parameters: P;
   readonly contentType: null;
-}
+};
 
-export interface IncomingEmptyRequest<P extends object> {
-  readonly parameters: P;
+export type IncomingEmptyRequest<P extends object> = ParametersContainer<P> & {
   readonly contentType: null;
-}
+};
 
-export interface IncomingEmptyResponse<S extends StatusCode, P extends object> {
+export type IncomingEmptyResponse<
+  S extends StatusCode,
+  P extends object,
+> = ParametersContainer<P> & {
   readonly status: S;
-  readonly parameters: P;
   readonly contentType: null;
-}
+};

--- a/packages/npm/oa42-lib/src/models/empty.ts
+++ b/packages/npm/oa42-lib/src/models/empty.ts
@@ -1,35 +1,19 @@
 import { StatusCode } from "../utils/index.js";
-import { ParametersContainer } from "./parameters.js";
 
-export type OutgoingEmptyRequestDefault<P extends object> = ParametersContainer<P>;
-
-export type OutgoingEmptyRequest<P extends object> = ParametersContainer<P> & {
+export type OutgoingEmptyRequest = {
   readonly contentType: null;
 };
 
-export type OutgoingEmptyResponseDefault<
-  S extends StatusCode,
-  P extends object,
-> = ParametersContainer<P> & {
-  readonly status: S;
-};
-
-export type OutgoingEmptyResponse<
-  S extends StatusCode,
-  P extends object,
-> = ParametersContainer<P> & {
+export type OutgoingEmptyResponse<S extends StatusCode> = {
   readonly status: S;
   readonly contentType: null;
 };
 
-export type IncomingEmptyRequest<P extends object> = ParametersContainer<P> & {
+export type IncomingEmptyRequest = {
   readonly contentType: null;
 };
 
-export type IncomingEmptyResponse<
-  S extends StatusCode,
-  P extends object,
-> = ParametersContainer<P> & {
+export type IncomingEmptyResponse<S extends StatusCode> = {
   readonly status: S;
   readonly contentType: null;
 };

--- a/packages/npm/oa42-lib/src/models/index.ts
+++ b/packages/npm/oa42-lib/src/models/index.ts
@@ -1,4 +1,5 @@
 export * from "./empty.js";
 export * from "./json.js";
+export * from "./parameters.js";
 export * from "./stream.js";
 export * from "./text.js";

--- a/packages/npm/oa42-lib/src/models/json.ts
+++ b/packages/npm/oa42-lib/src/models/json.ts
@@ -1,39 +1,39 @@
 import { Promisable } from "type-fest";
 import { StatusCode } from "../utils/index.js";
+import { ParametersContainer } from "./parameters.js";
 import { deserializeTextLines, deserializeTextValue } from "./text.js";
 
 //#region interfaces
 
-export type OutgoingJsonRequestDefault<P extends object, T> = {
-  readonly parameters: P;
-} & OutgoingJsonContainer<T>;
+export type OutgoingJsonRequestDefault<P extends object, T> = ParametersContainer<P> &
+  OutgoingJsonContainer<T>;
 
 export type OutgoingJsonRequest<P extends object, C extends string, T> = {
-  readonly parameters: P;
   readonly contentType: C;
-} & OutgoingJsonContainer<T>;
+} & ParametersContainer<P> &
+  OutgoingJsonContainer<T>;
 
 export type OutgoingJsonResponseDefault<S extends StatusCode, P extends object, T> = {
   readonly status: S;
-  readonly parameters: P;
-} & OutgoingJsonContainer<T>;
+} & ParametersContainer<P> &
+  OutgoingJsonContainer<T>;
 
 export type OutgoingJsonResponse<S extends StatusCode, P extends object, C extends string, T> = {
   readonly status: S;
-  readonly parameters: P;
   readonly contentType: C;
-} & OutgoingJsonContainer<T>;
+} & ParametersContainer<P> &
+  OutgoingJsonContainer<T>;
 
 export type IncomingJsonRequest<P extends object, C extends string, T> = {
-  readonly parameters: P;
   readonly contentType: C;
-} & IncomingJsonContainer<T>;
+} & ParametersContainer<P> &
+  IncomingJsonContainer<T>;
 
 export type IncomingJsonResponse<S extends StatusCode, P extends object, C extends string, T> = {
   readonly status: S;
-  readonly parameters: P;
   readonly contentType: C;
-} & IncomingJsonContainer<T>;
+} & ParametersContainer<P> &
+  IncomingJsonContainer<T>;
 
 //#endregion
 

--- a/packages/npm/oa42-lib/src/models/json.ts
+++ b/packages/npm/oa42-lib/src/models/json.ts
@@ -1,39 +1,26 @@
 import { Promisable } from "type-fest";
 import { StatusCode } from "../utils/index.js";
-import { ParametersContainer } from "./parameters.js";
 import { deserializeTextLines, deserializeTextValue } from "./text.js";
 
 //#region interfaces
 
-export type OutgoingJsonRequestDefault<P extends object, T> = ParametersContainer<P> &
-  OutgoingJsonContainer<T>;
-
-export type OutgoingJsonRequest<P extends object, C extends string, T> = {
+export type OutgoingJsonRequest<C extends string, T> = {
   readonly contentType: C;
-} & ParametersContainer<P> &
-  OutgoingJsonContainer<T>;
+} & OutgoingJsonContainer<T>;
 
-export type OutgoingJsonResponseDefault<S extends StatusCode, P extends object, T> = {
-  readonly status: S;
-} & ParametersContainer<P> &
-  OutgoingJsonContainer<T>;
-
-export type OutgoingJsonResponse<S extends StatusCode, P extends object, C extends string, T> = {
+export type OutgoingJsonResponse<S extends StatusCode, C extends string, T> = {
   readonly status: S;
   readonly contentType: C;
-} & ParametersContainer<P> &
-  OutgoingJsonContainer<T>;
+} & OutgoingJsonContainer<T>;
 
-export type IncomingJsonRequest<P extends object, C extends string, T> = {
+export type IncomingJsonRequest<C extends string, T> = {
   readonly contentType: C;
-} & ParametersContainer<P> &
-  IncomingJsonContainer<T>;
+} & IncomingJsonContainer<T>;
 
-export type IncomingJsonResponse<S extends StatusCode, P extends object, C extends string, T> = {
+export type IncomingJsonResponse<S extends StatusCode, C extends string, T> = {
   readonly status: S;
   readonly contentType: C;
-} & ParametersContainer<P> &
-  IncomingJsonContainer<T>;
+} & IncomingJsonContainer<T>;
 
 //#endregion
 

--- a/packages/npm/oa42-lib/src/models/parameters.ts
+++ b/packages/npm/oa42-lib/src/models/parameters.ts
@@ -1,0 +1,3 @@
+export interface ParametersContainer<P extends object> {
+  parameters: P;
+}

--- a/packages/npm/oa42-lib/src/models/parameters.ts
+++ b/packages/npm/oa42-lib/src/models/parameters.ts
@@ -1,3 +1,7 @@
 export interface ParametersContainer<P extends object> {
   parameters: P;
 }
+
+export interface OptionalParametersContainer<P extends object> {
+  parameters?: P;
+}

--- a/packages/npm/oa42-lib/src/models/stream.ts
+++ b/packages/npm/oa42-lib/src/models/stream.ts
@@ -1,43 +1,48 @@
 import { StatusCode } from "../utils/index.js";
+import { ParametersContainer } from "./parameters.js";
 
 //#region interfaces
 
-export interface OutgoingStreamRequestDefault<P extends object> {
-  readonly parameters: P;
-  stream(signal?: AbortSignal): AsyncIterable<Uint8Array>;
-}
+export type OutgoingStreamRequestDefault<P extends object> = ParametersContainer<P> &
+  OutgoingStreamContainer;
 
-export interface OutgoingStreamRequest<P extends object, C extends string> {
-  readonly parameters: P;
-  readonly contentType: C;
-  stream(signal?: AbortSignal): AsyncIterable<Uint8Array>;
-}
+export type OutgoingStreamRequest<P extends object, C extends string> = ParametersContainer<P> &
+  OutgoingStreamContainer & {
+    readonly contentType: C;
+  };
 
-export interface OutgoingStreamResponseDefault<S extends StatusCode, P extends object> {
-  readonly status: S;
-  readonly parameters: P;
-  stream(signal?: AbortSignal): AsyncIterable<Uint8Array>;
-}
+export type OutgoingStreamResponseDefault<
+  S extends StatusCode,
+  P extends object,
+> = ParametersContainer<P> &
+  OutgoingStreamContainer & {
+    readonly status: S;
+  };
 
-export interface OutgoingStreamResponse<S extends StatusCode, P extends object, C extends string> {
-  readonly status: S;
-  readonly parameters: P;
-  readonly contentType: C;
-  stream(signal?: AbortSignal): AsyncIterable<Uint8Array>;
-}
+export type OutgoingStreamResponse<
+  S extends StatusCode,
+  P extends object,
+  C extends string,
+> = ParametersContainer<P> &
+  OutgoingStreamContainer & {
+    readonly status: S;
+    readonly contentType: C;
+  };
 
-export interface IncomingStreamRequest<P extends object, C extends string> {
-  readonly parameters: P;
-  readonly contentType: C;
-  stream(signal?: AbortSignal): AsyncIterable<Uint8Array>;
-}
+export type IncomingStreamRequest<P extends object, C extends string> = ParametersContainer<P> &
+  IncomingStreamContainer & {
+    readonly contentType: C;
+  };
 
-export interface IncomingStreamResponse<S extends StatusCode, P extends object, C extends string> {
-  readonly status: S;
-  readonly parameters: P;
-  readonly contentType: C;
-  stream(signal?: AbortSignal): AsyncIterable<Uint8Array>;
-}
+export type IncomingStreamResponse<
+  S extends StatusCode,
+  P extends object,
+  C extends string,
+> = ParametersContainer<P> &
+  IncomingStreamContainer & {
+    readonly status: S;
+    readonly contentType: C;
+  };
 
 //#endregion
 

--- a/packages/npm/oa42-lib/src/models/stream.ts
+++ b/packages/npm/oa42-lib/src/models/stream.ts
@@ -3,20 +3,9 @@ import { ParametersContainer } from "./parameters.js";
 
 //#region interfaces
 
-export type OutgoingStreamRequestDefault<P extends object> = ParametersContainer<P> &
-  OutgoingStreamContainer;
-
 export type OutgoingStreamRequest<P extends object, C extends string> = ParametersContainer<P> &
   OutgoingStreamContainer & {
     readonly contentType: C;
-  };
-
-export type OutgoingStreamResponseDefault<
-  S extends StatusCode,
-  P extends object,
-> = ParametersContainer<P> &
-  OutgoingStreamContainer & {
-    readonly status: S;
   };
 
 export type OutgoingStreamResponse<

--- a/packages/npm/oa42-lib/src/models/text.ts
+++ b/packages/npm/oa42-lib/src/models/text.ts
@@ -1,38 +1,25 @@
 import { Promisable } from "type-fest";
 import { StatusCode } from "../utils/status-code.js";
-import { ParametersContainer } from "./parameters.js";
 
 //#region interfaces
 
-export type OutgoingTextRequestDefault<P extends object> = ParametersContainer<P> &
-  OutgoingTextContainer;
-
-export type OutgoingTextRequest<P extends object, C extends string> = {
+export type OutgoingTextRequest<C extends string> = {
   readonly contentType: C;
-} & ParametersContainer<P> &
-  OutgoingTextContainer;
+} & OutgoingTextContainer;
 
-export type OutgoingTextResponseDefault<S extends StatusCode, P extends object> = {
-  readonly status: S;
-} & ParametersContainer<P> &
-  OutgoingTextContainer;
-
-export type OutgoingTextResponse<S extends StatusCode, P extends object, C extends string> = {
+export type OutgoingTextResponse<S extends StatusCode, C extends string> = {
   readonly status: S;
   readonly contentType: C;
-} & ParametersContainer<P> &
-  OutgoingTextContainer;
+} & OutgoingTextContainer;
 
-export type IncomingTextRequest<P extends object, C extends string> = {
+export type IncomingTextRequest<C extends string> = {
   readonly contentType: C;
-} & ParametersContainer<P> &
-  IncomingTextContainer;
+} & IncomingTextContainer;
 
-export type IncomingTextResponse<S extends StatusCode, P extends object, C extends string> = {
+export type IncomingTextResponse<S extends StatusCode, C extends string> = {
   readonly status: S;
   readonly contentType: C;
-} & ParametersContainer<P> &
-  IncomingTextContainer;
+} & IncomingTextContainer;
 
 //#endregion
 

--- a/packages/npm/oa42-lib/src/models/text.ts
+++ b/packages/npm/oa42-lib/src/models/text.ts
@@ -1,38 +1,38 @@
 import { Promisable } from "type-fest";
 import { StatusCode } from "../utils/status-code.js";
+import { ParametersContainer } from "./parameters.js";
 
 //#region interfaces
 
-export type OutgoingTextRequestDefault<P extends object> = {
-  readonly parameters: P;
-} & OutgoingTextContainer;
+export type OutgoingTextRequestDefault<P extends object> = ParametersContainer<P> &
+  OutgoingTextContainer;
 
 export type OutgoingTextRequest<P extends object, C extends string> = {
-  readonly parameters: P;
   readonly contentType: C;
-} & OutgoingTextContainer;
+} & ParametersContainer<P> &
+  OutgoingTextContainer;
 
 export type OutgoingTextResponseDefault<S extends StatusCode, P extends object> = {
   readonly status: S;
-  readonly parameters: P;
-} & OutgoingTextContainer;
+} & ParametersContainer<P> &
+  OutgoingTextContainer;
 
 export type OutgoingTextResponse<S extends StatusCode, P extends object, C extends string> = {
   readonly status: S;
-  readonly parameters: P;
   readonly contentType: C;
-} & OutgoingTextContainer;
+} & ParametersContainer<P> &
+  OutgoingTextContainer;
 
 export type IncomingTextRequest<P extends object, C extends string> = {
-  readonly parameters: P;
   readonly contentType: C;
-} & IncomingTextContainer;
+} & ParametersContainer<P> &
+  IncomingTextContainer;
 
 export type IncomingTextResponse<S extends StatusCode, P extends object, C extends string> = {
   readonly status: S;
-  readonly parameters: P;
   readonly contentType: C;
-} & IncomingTextContainer;
+} & ParametersContainer<P> &
+  IncomingTextContainer;
 
 //#endregion
 


### PR DESCRIPTION
often we see this:
```
  return {
    status: 204,
    parameters: {},
    contentType: null
  }
```

This pr makes is possible to leave out the parameters field, like this:
```
  return {
    status: 204,
    contentType: null
  }
```
